### PR TITLE
fix enterprise admin edit link

### DIFF
--- a/src/components/pages/AccountPageComponent.js
+++ b/src/components/pages/AccountPageComponent.js
@@ -66,7 +66,7 @@ class AccountPageComponent extends React.Component {
       this.state.authenticatedEnterprises.map(function(enterprise) {
         return (
           <li className='permission-item' key={enterprise.id}>{enterprise.name || 'ID: ' + enterprise.id}
-            <Link className="edit-enterprise" to={'/enterprise/' + enterprise.id}>{t('accountPage:edit')}</Link>
+            <Link className="edit-enterprise" to={'/admin/dashboard'}>{t('accountPage:edit')}</Link>
           </li>
         );
       })


### PR DESCRIPTION
The "Edit" link in the Account screen was not working when you are a enterprise admin. I tried linking to dashboard/published/{enterprise id} but this didn't work and I didn't feel like coding for that so I'm just redirecting to the main dashboard page for now.